### PR TITLE
Bug fixes

### DIFF
--- a/imusensor/MPU9250/MPU9250.py
+++ b/imusensor/MPU9250/MPU9250.py
@@ -291,7 +291,7 @@ class MPU9250:
 		print ("Acceleration calibration is starting and keep placing the IMU in 6 different directions based on the instructions below")
 		time.sleep(2)
 		for i in range(6):
-			print ("Put the IMU in {0} position".format(i+1))
+			input("Put the IMU in {0} position. Press enter to continue..".format(i+1))
 			time.sleep(3)
 			meanvals = self.__getAccelVals()
 			print (meanvals)

--- a/imusensor/MPU9250/MPU9250.py
+++ b/imusensor/MPU9250/MPU9250.py
@@ -52,7 +52,7 @@ class MPU9250:
 		self.__writeRegister(self.cfg.PowerManagement1, self.cfg.ClockPLL)
 
 		name = self.__whoAmI()
-		if not (name[0] == 113 | name[0] == 115 ):
+		if not (name[0] == 113 or name[0] == 115 ):
 			print ("The name is wrong {0}".format(name))
 		self.__writeRegister(self.cfg.PowerManagement2, self.cfg.SensorEnable)
 


### PR DESCRIPTION
Hi,

I've made two minor changes to your code and wanted to let you know.

First, changing `if not (name[0] == 113 | name[0] == 115 ):` to `if not (name[0] == 113 or name[0] == 115 ):` should fix Issue #7.

Secondly, I found the calibration routine for the accelerometer a bit hectic. Therefore, I changed the routine so that it waits until the user confirms that the IMU is in the new position by hitting enter.